### PR TITLE
Some fixes for Raw CA/Wavelet/Preferences

### DIFF
--- a/content/Chromatic_Aberration/index.md
+++ b/content/Chromatic_Aberration/index.md
@@ -38,7 +38,7 @@ quality of demosaicing.
 
 ## Auto-Correction
 
-If "Auto-correction" is checked, the "Red"/"Blue" sliders are disabled
+If Auto-correction is checked, the "Red"/"Blue" sliders are disabled
 and an automated detection and correction of chromatic aberration is
 performed. Where manual correction applies a constant value across the
 image, auto-correction divides the image into many blocks and tailors
@@ -49,9 +49,9 @@ sliders.
 
 ## Iterations
 
-This setting is available if "Auto-Correct" is checked. Auto-Correction
+This setting is available if Auto-Correction is checked. Auto-Correction
 is conservative, means it often does not correct all Chromatic
-Abberation. To correct the remaining Chromatic Aberration, from RT 5.5
+Abberation. To correct the remaining Chromatic Aberration, from RawTherapee 5.5
 on you can use up to 5 iterations of automatic Chromatic Aberration
 correction. Each iteration will reduce the remaing Chromatic Aberration
 from the last iteration at the cost of additional processing time.
@@ -60,4 +60,4 @@ from the last iteration at the cost of additional processing time.
 
 If the "Red"/"Blue" sliders are non-zero the given values are used to
 correct chromatic aberration. They cannot be used at the same time as
-"Auto-correction".
+Auto-correction.

--- a/content/Color_Management/index.md
+++ b/content/Color_Management/index.md
@@ -949,7 +949,7 @@ temperature range, it is necessary to take Cat16 into account in CIECAM:
 - Choose the new temperature in "White balance" - for example 6000K.
 - Select Color Appearance & Lighting (CIECAM02/16).
 - Select: CAM Model = CIECAM16.
-- Select CatO2/16 mode = Automatic Symmetric.
+- Select Cat02/16 mode = Automatic Symmetric.
 - Adjust the temperature in Viewing Conditions to that of the white
   balance (in this example 6000K),
 - Then use the same process as before.

--- a/content/Preferences/index.md
+++ b/content/Preferences/index.md
@@ -473,11 +473,12 @@ RawTherapee to the folder which contains color profiles.
 
 Standard locations where color profiles are stored:
 
-:; Windows
-
-
-
-`C:\Windows\system32\spool\drivers\color`
+Windows
+    `C:\Windows\system32\spool\drivers\color`
+Linux
+    `/usr/share/color/icc/`
+macOS
+    `/library/ColorSync/Profiles/Displays/`
 
 ### Monitor
 
@@ -605,7 +606,7 @@ states:
 `[-]` Values differ across selected images.
 
 Batch editing is done by selecting multiple images in the
-[File Browser](the_file_browser_tab) (hold the or key, then click
+[File Browser](the_file_browser_tab) (hold the ⇧ Shift or ^ Ctrl key, then click
 the images you want to select), then you can edit those images using the
 tools in the Batch Edit panel on the right.
 
@@ -622,7 +623,7 @@ care what you're doing.
 What happens to the tool values as you manipulate them depends on the
 "Behavior" setting in this Batch Edit tab.
 
-The "Add" Mode
+#### The "Add" Mode
 This mode may also be understood as "relative". Modifying sliders which
 are set to the "Add" mode will result in the value of the modification
 being added to the existing value. For example, if you select two images
@@ -641,7 +642,7 @@ each selected image.
 
 <!-- -->
 
-The "Set" Mode
+#### The "Set" Mode
 This mode may also be understood as "absolute". Modifying sliders which
 are set to the "Set" mode will result in the value of the modification
 being set, irrelevant of what the existing value was. If we use the same

--- a/content/Preferences/index.md
+++ b/content/Preferences/index.md
@@ -37,7 +37,7 @@ monitor or more. The following modes are available:
 - Single Editor Tab Mode
 - Single Editor Tab Mode, Vertical Tabs
 - Multiple Editor Tabs Mode
-- Multiple Editor Tabs Mode (if available on second monitor)
+- Multiple Editor Tabs In Own Window Mode
 
 <!-- -->
 

--- a/content/Preferences/index.md
+++ b/content/Preferences/index.md
@@ -166,7 +166,7 @@ particular importance to this paragraph are the properties of the area
 which surround the observed region. The way you perceive the colors of a
 photograph viewed on a screen depends in part on the colors of the area
 surrounding the photograph. You can read more about this in the
-[CIECAM02](ciecam02) article. In order to mitigate the errors
+[CIECAM02/16](ciecam02) article. In order to mitigate the errors
 the user makes while adjusting a photo, RawTherapee ships themes which
 use neutral background colors. While all of the themes are based on
 shades of grey, the theme which is most suited to avoid affecting human
@@ -217,19 +217,17 @@ screenshot) visible in the
 <figcaption>Rt56_hidpi.png</figcaption>
 </figure>
 
-- Pseudo-HiDPI mode
-
-
-Scales the user interface so that text and images remain sharp even on a
-HiDPI screen. Introduced in RawTherapee 5.6. Scaling in RawTherapee
-depends on font size, DPI and display scaling. While scaling has been
-tested to work well in Windows, Linux and macOS, there are some macOS
-display modes which are incompatible with it, specifically those modes
-suffixed by "(HiDPI)" in macOS Display settings. Some versions of macOS
-(10.14.\*) seem to not list any modes, in which case the user must just
-give it a try.
-
 ### Clipping Indication
+
+The clipped [shadow](/static/images/Warning-shadows.png) and [highlight](/static/images/Warning-highlights.png) indicators in the Editor allow you to easily see which areas of the image are too dark or too bright. Highlighted areas are shaded according to the much they transgress the thresholds.
+
+The thresholds for these indicators are defined in Preferences > General.
+
+The clipped shadow indicator will highlight areas where all three channels fall at or below the specified shadow threshold.
+
+The clipped highlight indicator will highlight areas where at least one channel lies at or above the specified highlight threshold. If you want to see only where all channels are clipped, then enable the luminosity preview mode in addition to the clipped highlight indicator.
+
+Clipping is calculated using data which depends on the state of the gamut button Gamut-hist.png which you can toggle above the main preview in the Editor tab. When the gamut button is enabled the working profile is used, otherwise the gamma-corrected output profile is used. 
 
 ### Pan Rate Amplification
 

--- a/content/Preferences/index.md
+++ b/content/Preferences/index.md
@@ -8,7 +8,7 @@ contributors:
 ---
 
 You can access the Preferences window by clicking on the Preferences
-button [image:preferences.png](image:preferences.png) which
+button [preferences](/static/images/Preferences.png) which
 is either in the bottom-left corner of the RawTherapee window, or the
 top-right one, depending on your
 [Editor tab mode layout](the_image_editor_tab#editor_tab_modes).

--- a/content/Preferences/index.md
+++ b/content/Preferences/index.md
@@ -361,8 +361,7 @@ if you're using paths containing spaces.
 ### Directories
 
 Specify the location of your [Dark-Frame](dark-frame),
-[Flat-Field](flat-field) and
-[HaldCLUT Film Simulation](film_simulation) folders.
+[Flat-Field](flat-field), [HaldCLUT Film Simulation](film_simulation), Camera/Lens profiles and Lensfun database folders.
 
 ### Crop Editing
 

--- a/content/Wavelet_Levels/index.md
+++ b/content/Wavelet_Levels/index.md
@@ -2048,7 +2048,7 @@ will only have to re-select the desired *level* when you re-activate the
 module.
 
 The *merging* in the *Sharp Mask* consists of enhancing the details
-below the selected level and merging (blending) the result with the
+equal to and below the selected level and merging (blending) the result with the
 remaining levels: if you have selected *level 3*, the details of levels
 *1*, *2* and *3* will be enhanced and then merged with levels 4 and
 above (including the residual image). The *merge* slider allows you to


### PR DESCRIPTION
Summary of changes:

Raw CA: 
1. Auto-correction -> Auto-Correction, per RawPedia writing guideline.
2. RT 5.5 -> RawTherapee 5.5, per RawPedia writing guideline.

Wavelet:
Added "equal to" to: enhancing the details **_equal to_** and below the selected level and merging (blending) the result with the remaining levels: if you have selected *level 3*, the details of levels *1*, *2* and *3* will be enhanced and then merged with levels 4 and above.

Preferences:
1. For some reasons, Clipping Indication and color profile's standard location for Linux and MacOS are gone. Added them back from the current RawPedia.
2. Removed Psedo-HiDPI since it's no longer in RawTherapee.
3. Some small fixes on certain images' directory (I only fixed those I found when I was doing translation and I assume not all are fixed).
4. Small fixes to make tool name/options in line with current RawTherapee. Also small formatting change to align it with current RawPedia because some formatting also seems lost.

Please let me know if there is any issue, thanks.